### PR TITLE
$CHILD_STATUS is nil without require 'English'

### DIFF
--- a/project_helper/project_helper.rb
+++ b/project_helper/project_helper.rb
@@ -1,6 +1,7 @@
 require 'xcodeproj'
 require 'json'
 require 'plist'
+require 'English'
 
 # ProjectHelper ...
 class ProjectHelper


### PR DESCRIPTION
I noticed this when debugging


```Ruby
require_relative 'project_helper/project_helper.rb'

# https://github.com/instructure/instructure-ios
xcworkspace_path = './AllTheThings.xcworkspace'
xcode_proj_path = './rn/Teacher/ios/Teacher.xcodeproj'

# `codesign_identity': unkown project path:
# ProjectHelper.new(xcworkspace_path).codesign_identity(xcworkspace_path)

ProjectHelper.new(xcworkspace_path).codesign_identity(xcode_proj_path)
```