### PR TITLE
Provide empty target_attributes if it doesn't exist

### DIFF
--- a/project_helper/project_helper.rb
+++ b/project_helper/project_helper.rb
@@ -165,7 +165,7 @@ class ProjectHelper
       # force target attributes
       target_id = target_obj.uuid
       attributes = project.root_object.attributes['TargetAttributes']
-      target_attributes = attributes[target_id]
+      target_attributes = attributes[target_id] || {}
       target_attributes['ProvisioningStyle'] = 'Manual'
       target_attributes['DevelopmentTeam'] = development_team
       target_attributes['DevelopmentTeamName'] = ''

--- a/project_helper/project_helper.rb
+++ b/project_helper/project_helper.rb
@@ -164,7 +164,7 @@ class ProjectHelper
 
       # force target attributes
       target_id = target_obj.uuid
-      attributes = project.root_object.attributes['TargetAttributes']
+      attributes = project.root_object.attributes['TargetAttributes'] || {}
       target_attributes = attributes[target_id] || {}
       target_attributes['ProvisioningStyle'] = 'Manual'
       target_attributes['DevelopmentTeam'] = development_team


### PR DESCRIPTION
Fixes #18, Fixes #20 

This provides a default empty `target_attributes` if it doesn't exist in the project. 
I'm not a ruby dev, so I'm not even sure if this is syntactically correct.