### PR TITLE
Fix the bundle ID expand issue

### DIFF
--- a/autoprovision/projecthelper_test.go
+++ b/autoprovision/projecthelper_test.go
@@ -405,6 +405,30 @@ func Test_resolveBundleID(t *testing.T) {
 			want:    "Bitrise.Test.Sample.Suffix",
 			wantErr: false,
 		},
+		{
+			name:     "com.brainbow.${PRODUCT_NAME}",
+			bundleID: "com.brainbow.${PRODUCT_NAME}",
+			buildSettings: func() map[string]interface{} {
+				m := make(map[string]interface{})
+				m["PRODUCT_NAME"] = "Sample"
+				m["a"] = "Sample"
+				return m
+			}(),
+			want:    "com.brainbow.Sample",
+			wantErr: false,
+		},
+		{
+			name:     "com.brainbow.${PRODUCT_NAME}.Suffix",
+			bundleID: "com.brainbow.${PRODUCT_NAME}.Suffix",
+			buildSettings: func() map[string]interface{} {
+				m := make(map[string]interface{})
+				m["PRODUCT_NAME"] = "Sample"
+				m["a"] = "Sample"
+				return m
+			}(),
+			want:    "com.brainbow.Sample.Suffix",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/autoprovision/projecthelper_test.go
+++ b/autoprovision/projecthelper_test.go
@@ -406,27 +406,27 @@ func Test_resolveBundleID(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:     "com.brainbow.${PRODUCT_NAME}",
-			bundleID: "com.brainbow.${PRODUCT_NAME}",
+			name:     "com.braw.${PRODUCT_NAME}",
+			bundleID: "com.braw.${PRODUCT_NAME}",
 			buildSettings: func() map[string]interface{} {
 				m := make(map[string]interface{})
 				m["PRODUCT_NAME"] = "Sample"
 				m["a"] = "Sample"
 				return m
 			}(),
-			want:    "com.brainbow.Sample",
+			want:    "com.braw.Sample",
 			wantErr: false,
 		},
 		{
-			name:     "com.brainbow.${PRODUCT_NAME}.Suffix",
-			bundleID: "com.brainbow.${PRODUCT_NAME}.Suffix",
+			name:     "com.braw.${PRODUCT_NAME}.Suffix",
+			bundleID: "com.braw.${PRODUCT_NAME}.Suffix",
 			buildSettings: func() map[string]interface{} {
 				m := make(map[string]interface{})
 				m["PRODUCT_NAME"] = "Sample"
 				m["a"] = "Sample"
 				return m
 			}(),
-			want:    "com.brainbow.Sample.Suffix",
+			want:    "com.braw.Sample.Suffix",
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
JIRA ticket:
https://bitrise.atlassian.net/browse/TOOL-729

---

**Description**
The step reads the bundleID from the .pbxproj file but, the bundle ID is not exposed in the .pbxproj file ( raw ).
If the raw BundleID contains an environment variable we have to replace it.

**Example:**
BundleID in the .pbxproj: `Bitrise.Test.$(PRODUCT_NAME:rfc1034identifier).Suffix`
BundleID after the env is expanded: `Bitrise.Test.Sample.Suffix`

----

**Issue**
The step is not able to expand bundle id like this: `com.braw.${PRODUCT_NAME}`

**Fix**
Replace the old strict regex logic with a new "more general" one.