### PR TITLE
Tool 1290 cleanup log

### DIFF
--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -138,7 +138,7 @@ func checkResponse(r *http.Response) error {
 	data, err := ioutil.ReadAll(r.Body)
 	if err == nil && data != nil {
 		if err := json.Unmarshal(data, errorResponse); err != nil {
-			log.Errorf("Failed to unmarshal response: %s", err)
+			log.Errorf("Failed to unmarshal response (%s): %s", string(data), err)
 		}
 	}
 	return errorResponse

--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -136,7 +136,7 @@ func checkResponse(r *http.Response) error {
 	data, err := ioutil.ReadAll(r.Body)
 	if err == nil && data != nil {
 		if err := json.Unmarshal(data, errorResponse); err != nil {
-			log.Errorf("Failed to unmarshal response, error: %s", err)
+			log.Errorf("Failed to unmarshal response: %s", err)
 		}
 	}
 	return errorResponse
@@ -161,7 +161,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
-			log.Warnf("failed to close response body, error: %s", cerr)
+			log.Warnf("Failed to close response body: %s", cerr)
 		}
 	}()
 

--- a/appstoreconnect/appstoreconnect.go
+++ b/appstoreconnect/appstoreconnect.go
@@ -28,6 +28,8 @@ type service struct {
 
 // Client communicate with the Apple API
 type Client struct {
+	EnableDebugLogs bool
+
 	keyID             string
 	issuerID          string
 	privateKeyContent []byte
@@ -142,18 +144,29 @@ func checkResponse(r *http.Response) error {
 	return errorResponse
 }
 
+// Debugf ...
+func (c *Client) Debugf(format string, v ...interface{}) {
+	if c.EnableDebugLogs {
+		log.Debugf(format, v...)
+	}
+}
+
 // Do ...
 func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
-	log.Debugf("Request:")
-	if err := httputil.PrintRequest(req); err != nil {
-		log.Debugf("Failed to print request: %s", err)
+	c.Debugf("Request:")
+	if c.EnableDebugLogs {
+		if err := httputil.PrintRequest(req); err != nil {
+			c.Debugf("Failed to print request: %s", err)
+		}
 	}
 
 	resp, err := c.client.Do(req)
 
-	log.Debugf("Response:")
-	if err := httputil.PrintResponse(resp); err != nil {
-		log.Debugf("Failed to print response: %s", err)
+	c.Debugf("Response:")
+	if c.EnableDebugLogs {
+		if err := httputil.PrintResponse(resp); err != nil {
+			c.Debugf("Failed to print response: %s", err)
+		}
 	}
 
 	if err != nil {

--- a/appstoreconnect/bundleids.go
+++ b/appstoreconnect/bundleids.go
@@ -101,7 +101,7 @@ func (s ProvisioningService) FetchBundleID(bundleID string) (BundleID, error) {
 		FilterIdentifier: bundleID,
 	})
 	if err != nil {
-		return BundleID{}, fmt.Errorf("failed to fetch bundle ID %s from App Store Connect, error :%s", bundleID, err)
+		return BundleID{}, fmt.Errorf("failed to fetch bundle ID %s from App Store Connect: %s", bundleID, err)
 	}
 
 	if len(r.Data) == 0 {

--- a/appstoreconnect/certificates.go
+++ b/appstoreconnect/certificates.go
@@ -93,7 +93,7 @@ func (s ProvisioningService) FetchCertificate(serialNumber string) (Certificate,
 		FilterSerialNumber: serialNumber,
 	})
 	if err != nil {
-		return Certificate{}, fmt.Errorf("failed to fetch certificate %s, error :%s", serialNumber, err)
+		return Certificate{}, fmt.Errorf("failed to fetch certificate %s: %s", serialNumber, err)
 	}
 
 	if len(r.Data) == 0 {

--- a/appstoreconnect/certificates.go
+++ b/appstoreconnect/certificates.go
@@ -93,13 +93,13 @@ func (s ProvisioningService) FetchCertificate(serialNumber string) (Certificate,
 		FilterSerialNumber: serialNumber,
 	})
 	if err != nil {
-		return Certificate{}, fmt.Errorf("failed to fetch certificate %s: %s", serialNumber, err)
+		return Certificate{}, fmt.Errorf("failed to fetch certificate (%s): %s", serialNumber, err)
 	}
 
 	if len(r.Data) == 0 {
-		return Certificate{}, fmt.Errorf("no certificate with serial %s found", serialNumber)
-	} else if len(r.Data) == 0 {
-		return Certificate{}, fmt.Errorf("multiple certificates with serial %s found: %s", serialNumber, r.Data)
+		return Certificate{}, fmt.Errorf("no certificate found with serial %s", serialNumber)
+	} else if len(r.Data) > 1 {
+		return Certificate{}, fmt.Errorf("multiple certificates found with serial %s: %s", serialNumber, r.Data)
 	}
 	return r.Data[0], nil
 }

--- a/autoprovision/bundleidhelper.go
+++ b/autoprovision/bundleidhelper.go
@@ -13,7 +13,7 @@ func FindBundleID(client *appstoreconnect.Client, bundleIDIdentifier string) (*a
 		FilterIdentifier: bundleIDIdentifier,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch bundleID: %s, error: %s", bundleIDIdentifier, err)
+		return nil, fmt.Errorf("failed to fetch bundleID (%s): %s", bundleIDIdentifier, err)
 	}
 	if len(r.Data) == 0 {
 		return nil, nil
@@ -135,7 +135,7 @@ func CreateBundleID(client *appstoreconnect.Client, bundleIDIdentifier string, e
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register AppID for bundleID %s, error: %s", bundleIDIdentifier, err)
+		return nil, fmt.Errorf("failed to register AppID for bundleID (%s): %s", bundleIDIdentifier, err)
 	}
 
 	return &r.Data, nil

--- a/autoprovision/certificatehelper.go
+++ b/autoprovision/certificatehelper.go
@@ -68,7 +68,7 @@ func queryAllIOSCertificates(client *appstoreconnect.Client) (map[appstoreconnec
 	for _, certType := range []appstoreconnect.CertificateType{appstoreconnect.IOSDevelopment, appstoreconnect.IOSDistribution} {
 		certs, err := queryCertificatesByType(client, certType)
 		if err != nil {
-			return map[appstoreconnect.CertificateType][]APICertificate{}, fmt.Errorf("failed to query certificates, error: %s", err)
+			return map[appstoreconnect.CertificateType][]APICertificate{}, err
 		}
 		typeToCertificates[certType] = certs
 	}
@@ -116,12 +116,12 @@ func parseCertificatesResponse(response []appstoreconnect.Certificate) ([]APICer
 		if connectCertResponse.Type == "certificates" {
 			certificateData, err := base64.StdEncoding.DecodeString(connectCertResponse.Attributes.CertificateContent)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode certificate connect, error: %s", err)
+				return nil, fmt.Errorf("failed to decode certificate content: %s", err)
 			}
 
 			cert, err := x509.ParseCertificate(certificateData)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse certificate, error: %s", err)
+				return nil, fmt.Errorf("failed to parse certificate: %s", err)
 			}
 
 			certInfo := certificateutil.NewCertificateInfo(*cert, nil)
@@ -173,7 +173,7 @@ func GetValidCertificates(localCertificates []certificateutil.CertificateInfoMod
 
 	if logAllAPICerts {
 		if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
-			return nil, fmt.Errorf("failed to log all Developer Portal certificates, error: %s", err)
+			return nil, fmt.Errorf("failed to log all Developer Portal certificates: %s", err)
 		}
 	}
 
@@ -195,7 +195,7 @@ func GetValidCertificates(localCertificates []certificateutil.CertificateInfoMod
 		if requiredCertificateTypes[certificateType] && len(matchingCertificates) == 0 {
 			if !logAllAPICerts {
 				if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
-					log.Errorf("failed to log all Developer Portal certificates, error: %s", err)
+					log.Errorf("failed to log all Developer Portal certificates: %s", err)
 				}
 			}
 

--- a/autoprovision/certificatehelper.go
+++ b/autoprovision/certificatehelper.go
@@ -112,9 +112,9 @@ func queryCertificateBySerial(client *appstoreconnect.Client, serial *big.Int) (
 
 func parseCertificatesResponse(response []appstoreconnect.Certificate) ([]APICertificate, error) {
 	var certifacteInfos []APICertificate
-	for _, connectCertResponse := range response {
-		if connectCertResponse.Type == "certificates" {
-			certificateData, err := base64.StdEncoding.DecodeString(connectCertResponse.Attributes.CertificateContent)
+	for _, resp := range response {
+		if resp.Type == "certificates" {
+			certificateData, err := base64.StdEncoding.DecodeString(resp.Attributes.CertificateContent)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode certificate content: %s", err)
 			}
@@ -128,7 +128,7 @@ func parseCertificatesResponse(response []appstoreconnect.Certificate) ([]APICer
 
 			certifacteInfos = append(certifacteInfos, APICertificate{
 				Certificate: certInfo,
-				ID:          connectCertResponse.ID,
+				ID:          resp.ID,
 			})
 		}
 	}
@@ -137,48 +137,51 @@ func parseCertificatesResponse(response []appstoreconnect.Certificate) ([]APICer
 }
 
 // CertsToString ...
-func CertsToString(certs []certificateutil.CertificateInfoModel) string {
-	certInfo := "[\n"
-
-	for _, cert := range certs {
-		certInfo += cert.String() + "\n"
+func CertsToString(certs []certificateutil.CertificateInfoModel) (s string) {
+	for i, cert := range certs {
+		s += "- "
+		s += cert.String()
+		if i < len(certs)-1 {
+			s += "\n"
+		}
 	}
-	certInfo += "]"
+	return
+}
 
-	return certInfo
+// MissingCertificateError ...
+type MissingCertificateError struct {
+	Type   appstoreconnect.CertificateType
+	TeamID string
+}
+
+func (e MissingCertificateError) Error() string {
+	return fmt.Sprintf("no valid %s type certificates uploaded with Team ID (%s)\n ", e.Type, e.TeamID)
 }
 
 // GetValidCertificates ...
-func GetValidCertificates(localCertificates []certificateutil.CertificateInfoModel, client CertificateSource, requiredCertificateTypes map[appstoreconnect.CertificateType]bool, teamID string, logAllAPICerts bool) (map[appstoreconnect.CertificateType][]APICertificate, error) {
+func GetValidCertificates(localCertificates []certificateutil.CertificateInfoModel, client CertificateSource, requiredCertificateTypes map[appstoreconnect.CertificateType]bool, teamID string) (map[appstoreconnect.CertificateType][]APICertificate, error) {
 	typeToLocalCerts, err := GetValidLocalCertificates(localCertificates, teamID)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debugf("Certificate types required for Development: %t; Distribution: %t", requiredCertificateTypes[appstoreconnect.IOSDevelopment], requiredCertificateTypes[appstoreconnect.IOSDistribution])
+	log.Debugf("Certificates required for Development: %t; Distribution: %t", requiredCertificateTypes[appstoreconnect.IOSDevelopment], requiredCertificateTypes[appstoreconnect.IOSDistribution])
 
 	for certificateType, requried := range requiredCertificateTypes {
 		if !requried {
 			continue
 		}
-		if len(typeToLocalCerts[certificateType]) > 1 {
-			log.Warnf(`Multiple %s type certificates with Team ID "%s": %s`,
-				certificateType, teamID, CertsToString(typeToLocalCerts[certificateType]))
-		} else if len(typeToLocalCerts[certificateType]) == 0 {
-			log.Warnf("Maybe you forgot to provide a(n) %s type certificate.", certificateType)
-			log.Warnf("Upload a %s type certificate (.p12) on the Code Signing tab of the Workflow Editor.", certificateType)
-			return map[appstoreconnect.CertificateType][]APICertificate{}, fmt.Errorf("no valid %s type certificates uploaded with Team ID (%s)", certificateType, teamID)
+
+		if len(typeToLocalCerts[certificateType]) == 0 {
+			return map[appstoreconnect.CertificateType][]APICertificate{}, MissingCertificateError{certificateType, teamID}
+
 		}
 	}
 
-	if logAllAPICerts {
-		if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
-			return nil, fmt.Errorf("failed to log all Developer Portal certificates: %s", err)
-		}
+	// only for debugging
+	if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
+		log.Debugf("Failed to log all Developer Portal certificates: %s", err)
 	}
-
-	log.Debugf("")
-	log.Debugf("Querying Apple Developer Portal for matching certificates.")
 
 	validAPICertificates := map[appstoreconnect.CertificateType][]APICertificate{}
 	for certificateType, validLocalCertificates := range typeToLocalCerts {
@@ -187,19 +190,15 @@ func GetValidCertificates(localCertificates []certificateutil.CertificateInfoMod
 			return nil, err
 		}
 
-		log.Debugf("Certificates type %s having matches on Developer Portal:", certificateType)
-		for _, cert := range matchingCertificates {
-			log.Debugf("%s", cert.Certificate)
+		if len(matchingCertificates) > 0 {
+			log.Debugf("Certificates type %s has matches on Developer Portal:", certificateType)
+			for _, cert := range matchingCertificates {
+				log.Debugf("%s", cert.Certificate)
+			}
 		}
 
 		if requiredCertificateTypes[certificateType] && len(matchingCertificates) == 0 {
-			if !logAllAPICerts {
-				if err := LogAllAPICertificates(client, typeToLocalCerts); err != nil {
-					log.Errorf("failed to log all Developer Portal certificates: %s", err)
-				}
-			}
-
-			return nil, fmt.Errorf("not found any of the following %s certificates uploaded to Bitrise on Developer Portal: %s", certificateType, localCertificates)
+			return nil, fmt.Errorf("not found any of the following %s certificates on Developer Portal:\n%s", certificateType, CertsToString(localCertificates))
 		}
 
 		if len(matchingCertificates) > 0 {
@@ -212,26 +211,23 @@ func GetValidCertificates(localCertificates []certificateutil.CertificateInfoMod
 
 // GetValidLocalCertificates returns validated and deduplicated local certificates
 func GetValidLocalCertificates(certificates []certificateutil.CertificateInfoModel, teamID string) (map[appstoreconnect.CertificateType][]certificateutil.CertificateInfoModel, error) {
-	log.Debugf("")
-	log.Debugf("Filtering out invalid or duplicated name certificates.")
-
 	preFilteredCerts := certificateutil.FilterValidCertificateInfos(certificates)
 
 	if len(preFilteredCerts.InvalidCertificates) != 0 {
-		log.Debugf("Ignoring expired or not yet valid certificates: %s", preFilteredCerts.InvalidCertificates)
+		log.Warnf("Ignoring expired or not yet valid certificates: %s", preFilteredCerts.InvalidCertificates)
 	}
 	if len(preFilteredCerts.DuplicatedCertificates) != 0 {
 		log.Warnf("Ignoring duplicated certificates with the same name: %s", preFilteredCerts.DuplicatedCertificates)
 	}
-	log.Debugf("Valid and deduplicated common name certificates: %s", CertsToString(preFilteredCerts.ValidCertificates))
 
-	log.Debugf("")
-	log.Debugf(`Filtering certificates for developer Team ID (%s)`, teamID)
+	log.Debugf("Valid and deduplicated certificates:\n%s", CertsToString(preFilteredCerts.ValidCertificates))
 
 	localCertificates := map[appstoreconnect.CertificateType][]certificateutil.CertificateInfoModel{}
 	for _, certType := range []appstoreconnect.CertificateType{appstoreconnect.IOSDevelopment, appstoreconnect.IOSDistribution} {
 		localCertificates[certType] = filterCertificates(preFilteredCerts.ValidCertificates, certType, teamID)
 	}
+
+	log.Debugf("Valid and deduplicated certificates for Development team (%s):\n%s", teamID, CertsToString(preFilteredCerts.ValidCertificates))
 
 	return localCertificates, nil
 }
@@ -241,16 +237,15 @@ func MatchLocalToAPICertificates(client CertificateSource, certificateType appst
 	var matchingCertificates []APICertificate
 
 	for _, localCert := range localCertificates {
-		log.Debugf("Looking for certificate on Developer Portal: %s", localCert)
-
 		cert, err := client.queryCertificateBySerial(localCert.Certificate.SerialNumber)
 		if err != nil {
-			log.Warnf("Certificate not found on Developer Portal, %s", err)
+			log.Warnf("Certificate (%s) not found on Developer Portal: %s", localCert, err)
 			continue
 		}
 		cert.Certificate = localCert
 
-		log.Debugf("Found. ID: %s, %s ", cert.ID, cert.Certificate)
+		log.Debugf("Certificate (%s) found with ID: %s", localCert, cert.ID)
+
 		matchingCertificates = append(matchingCertificates, cert)
 	}
 
@@ -286,7 +281,7 @@ func filterCertificates(certificates []certificateutil.CertificateInfoModel, cer
 		}
 	}
 
-	log.Debugf("Valid certificates with type %s: %s", certificateType, CertsToString(filteredCertificates))
+	log.Debugf("Valid certificates with type %s:\n%s", certificateType, CertsToString(filteredCertificates))
 
 	if len(filteredCertificates) == 0 {
 		return nil
@@ -298,13 +293,13 @@ func filterCertificates(certificates []certificateutil.CertificateInfoModel, cer
 		filteredCertificates = certsByTeam[teamID]
 	}
 
-	log.Debugf("Valid certificates with type %s, Team ID: (%s): %s", certificateType, teamID, CertsToString(filteredCertificates))
+	log.Debugf("Valid certificates with type %s, Team ID: (%s):\n%s", certificateType, teamID, CertsToString(filteredCertificates))
 
 	if len(filteredCertificates) == 0 {
 		return nil
 	}
 
-	log.Debugf("Valid certificates with type %s, Team ID: (%s) %s ", certificateType, teamID, CertsToString(filteredCertificates))
+	log.Debugf("Valid certificates with type %s, Team ID: (%s)\n%s ", certificateType, teamID, CertsToString(filteredCertificates))
 
 	return filteredCertificates
 }

--- a/autoprovision/certificatehelper.go
+++ b/autoprovision/certificatehelper.go
@@ -193,7 +193,7 @@ func GetValidCertificates(localCertificates []certificateutil.CertificateInfoMod
 		if len(matchingCertificates) > 0 {
 			log.Debugf("Certificates type %s has matches on Developer Portal:", certificateType)
 			for _, cert := range matchingCertificates {
-				log.Debugf("%s", cert.Certificate)
+				log.Debugf("- %s", cert.Certificate)
 			}
 		}
 
@@ -262,7 +262,7 @@ func LogAllAPICertificates(client CertificateSource, localCertificates map[appst
 	for certType, certs := range certificates {
 		log.Debugf("Developer Portal %s certificates:", certType)
 		for _, cert := range certs {
-			log.Debugf("%s", cert.Certificate)
+			log.Debugf("- %s", cert.Certificate)
 		}
 	}
 

--- a/autoprovision/certificatehelper_test.go
+++ b/autoprovision/certificatehelper_test.go
@@ -67,7 +67,6 @@ func TestGetValidCertificates(t *testing.T) {
 		client                   CertificateSource
 		requiredCertificateTypes map[appstoreconnect.CertificateType]bool
 		teamID                   string
-		logAllCerts              bool
 	}
 	tests := []struct {
 		name    string
@@ -84,7 +83,6 @@ func TestGetValidCertificates(t *testing.T) {
 				client:                   mockAPIClient(map[appstoreconnect.CertificateType][]APICertificate{}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want:    map[appstoreconnect.CertificateType][]APICertificate{},
 			wantErr: true,
@@ -105,7 +103,6 @@ func TestGetValidCertificates(t *testing.T) {
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want: map[appstoreconnect.CertificateType][]APICertificate{
 				appstoreconnect.IOSDevelopment: []APICertificate{{
@@ -122,7 +119,6 @@ func TestGetValidCertificates(t *testing.T) {
 				client:                   mockAPIClient(map[appstoreconnect.CertificateType][]APICertificate{}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want:    map[appstoreconnect.CertificateType][]APICertificate{},
 			wantErr: true,
@@ -136,7 +132,6 @@ func TestGetValidCertificates(t *testing.T) {
 				client:                   mockAPIClient(map[appstoreconnect.CertificateType][]APICertificate{}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want:    map[appstoreconnect.CertificateType][]APICertificate{},
 			wantErr: true,
@@ -155,7 +150,6 @@ func TestGetValidCertificates(t *testing.T) {
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want: map[appstoreconnect.CertificateType][]APICertificate{
 				appstoreconnect.IOSDevelopment: []APICertificate{{
@@ -180,7 +174,6 @@ func TestGetValidCertificates(t *testing.T) {
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: false},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want: map[appstoreconnect.CertificateType][]APICertificate{
 				appstoreconnect.IOSDevelopment: []APICertificate{{
@@ -210,7 +203,6 @@ func TestGetValidCertificates(t *testing.T) {
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want:    map[appstoreconnect.CertificateType][]APICertificate{},
 			wantErr: true,
@@ -232,8 +224,7 @@ func TestGetValidCertificates(t *testing.T) {
 					appstoreconnect.IOSDevelopment:  true,
 					appstoreconnect.IOSDistribution: true,
 				},
-				teamID:      "",
-				logAllCerts: true,
+				teamID: "",
 			},
 			want:    map[appstoreconnect.CertificateType][]APICertificate{},
 			wantErr: true,
@@ -261,7 +252,6 @@ func TestGetValidCertificates(t *testing.T) {
 				}),
 				requiredCertificateTypes: map[appstoreconnect.CertificateType]bool{appstoreconnect.IOSDevelopment: true, appstoreconnect.IOSDistribution: true},
 				teamID:                   "",
-				logAllCerts:              true,
 			},
 			want: map[appstoreconnect.CertificateType][]APICertificate{
 				appstoreconnect.IOSDevelopment: []APICertificate{{
@@ -278,7 +268,7 @@ func TestGetValidCertificates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetValidCertificates(tt.args.localCertificates, tt.args.client, tt.args.requiredCertificateTypes, tt.args.teamID, tt.args.logAllCerts)
+			got, err := GetValidCertificates(tt.args.localCertificates, tt.args.client, tt.args.requiredCertificateTypes, tt.args.teamID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetValidCertificates() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/autoprovision/certificatehelper_test.go
+++ b/autoprovision/certificatehelper_test.go
@@ -43,21 +43,21 @@ func TestGetValidCertificates(t *testing.T) {
 
 	cert, privateKey, err := certificateutil.GenerateTestCertificate(int64(1), teamID, teamName, commonNameIOSDevelopment, expiry)
 	if err != nil {
-		t.Errorf("init: failed to generate certificate, error: %s", err)
+		t.Errorf("init: failed to generate certificate: %s", err)
 	}
 	devCert := certificateutil.NewCertificateInfo(*cert, privateKey)
 	t.Logf("Test certificate generated. %s", devCert)
 
 	cert, privateKey, err = certificateutil.GenerateTestCertificate(int64(2), teamID, teamName, "iPhone Developer: test2", expiry)
 	if err != nil {
-		t.Errorf("init: failed to generate certificate, error: %s", err)
+		t.Errorf("init: failed to generate certificate: %s", err)
 	}
 	devCert2 := certificateutil.NewCertificateInfo(*cert, privateKey)
 	t.Logf("Test certificate generated. %s", devCert)
 
 	distCert, privateKey, err := certificateutil.GenerateTestCertificate(int64(10), teamID, teamName, commonNameIOSDistribution, expiry)
 	if err != nil {
-		t.Errorf("init: failed to generate certificate, error: %s", err)
+		t.Errorf("init: failed to generate certificate: %s", err)
 	}
 	distributionCert := certificateutil.NewCertificateInfo(*distCert, privateKey)
 	t.Logf("Test certificate generated. %s", distributionCert)

--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -152,7 +152,7 @@ func CreateProfile(client *appstoreconnect.Client, profileType appstoreconnect.P
 		),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Manual %s provisioning profile for %s bundle ID, error: %s", profileType.ReadableString(), bundleID.Attributes.Identifier, err)
+		return nil, fmt.Errorf("failed to create %s provisioning profile for %s bundle ID: %s", profileType.ReadableString(), bundleID.Attributes.Identifier, err)
 	}
 	return &r.Data, nil
 }
@@ -164,10 +164,10 @@ func WriteProfile(profile appstoreconnect.Profile) error {
 	homeDir := os.Getenv("HOME")
 	profilesDir := path.Join(homeDir, "Library/MobileDevice/Provisioning Profiles")
 	if exists, err := pathutil.IsDirExists(profilesDir); err != nil {
-		return fmt.Errorf("failed to check directory for provisioning profiles (%s), error: %s", profilesDir, err)
+		return fmt.Errorf("failed to check directory (%s) for provisioning profiles: %s", profilesDir, err)
 	} else if !exists {
 		if err := os.MkdirAll(profilesDir, 0600); err != nil {
-			return fmt.Errorf("failed to generate directory for provisioning profiles (%s), error: %s", profilesDir, err)
+			return fmt.Errorf("failed to generate directory (%s) for provisioning profiles: %s", profilesDir, err)
 		}
 	}
 
@@ -182,11 +182,11 @@ func WriteProfile(profile appstoreconnect.Profile) error {
 
 	b, err := base64.StdEncoding.DecodeString(profile.Attributes.ProfileContent)
 	if err != nil {
-		return fmt.Errorf("failed to decode ( base 64 ) the profile content, error: %s", err)
+		return fmt.Errorf("failed to decode profile content: %s", err)
 	}
 	name := path.Join(profilesDir, profile.Attributes.UUID+ext)
 	if err := ioutil.WriteFile(name, b, 0600); err != nil {
-		return fmt.Errorf("failed to write profile to file, error: %s", err)
+		return fmt.Errorf("failed to write profile to file: %s", err)
 	}
 	return nil
 }

--- a/autoprovision/projecthelper.go
+++ b/autoprovision/projecthelper.go
@@ -170,6 +170,7 @@ func (p *ProjectHelper) ProjectTeamID(config string) (string, error) {
 			log.Debugf("%s target DevelopmentTeam attribute: %s", target.Name, targetAttributesTeamID)
 
 			if targetAttributesTeamID == "" {
+				log.Debugf("No team id found for %s target", target.Name)
 				continue
 			}
 

--- a/autoprovision/projecthelper.go
+++ b/autoprovision/projecthelper.go
@@ -190,39 +190,6 @@ func (p *ProjectHelper) ProjectTeamID(config string) (string, error) {
 
 }
 
-// ProjectCodeSignIdentity returns the codesign identity of the project
-// If there is mutlitple codesign identity in the project (different identity for targets) it will return an error
-// It returns the codesign identity
-func (p *ProjectHelper) ProjectCodeSignIdentity(config string) (string, error) {
-	var codesignIdentity string
-
-	for _, t := range p.Targets {
-		targetIdentity, err := p.targetCodesignIdentity(t.Name, config)
-		if err != nil {
-			return "", err
-		}
-
-		log.Debugf("%s codesign identity: %s", t.Name, targetIdentity)
-
-		if targetIdentity == "" {
-			log.Warnf("no CODE_SIGN_IDENTITY build settings found for target: %s", t.Name)
-			continue
-		}
-
-		if codesignIdentity == "" {
-			codesignIdentity = targetIdentity
-			continue
-		}
-
-		if !codesignIdentitesMatch(codesignIdentity, targetIdentity) {
-			log.Warnf("target codesign identity: %s does not match to the already registered codesign identity: %s", targetIdentity, codesignIdentity)
-			codesignIdentity = ""
-			break
-		}
-	}
-	return codesignIdentity, nil
-}
-
 func (p *ProjectHelper) targetCodesignIdentity(targatName, config string) (string, error) {
 	settings, err := p.targetBuildSettings(targatName, config)
 	if err != nil {

--- a/autoprovision/projecthelper_test.go
+++ b/autoprovision/projecthelper_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/sliceutil"
 
 	"github.com/bitrise-io/xcode-project/serialized"
 	"github.com/bitrise-io/xcode-project/xcodeproj"
@@ -212,71 +211,6 @@ func Test_codesignIdentitesMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := codesignIdentitesMatch(tt.identity1, tt.identity2); got != tt.want {
 				t.Errorf("codesignIdentitesMatch() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestProjectHelper_ProjectCodeSignIdentity(t *testing.T) {
-	var err error
-	schemeCases, _, _, projHelpCases, configCases, err = initTestCases()
-	if err != nil {
-		t.Fatalf("Failed to initialize test cases, error: %s", err)
-	}
-
-	tests := []struct {
-		name    string
-		config  string
-		want    []string
-		wantErr bool
-	}{
-		{
-			name:    schemeCases[0] + " Debug",
-			config:  configCases[0],
-			want:    []string{"iPhone Developer"},
-			wantErr: false,
-		},
-		{
-			name:    schemeCases[1] + " Release",
-			config:  configCases[1],
-			want:    []string{"iPhone Developer"},
-			wantErr: false,
-		},
-		{
-			name:    schemeCases[2] + " Debug",
-			config:  configCases[2],
-			want:    []string{"-"},
-			wantErr: false,
-		},
-		{
-			name:    schemeCases[3] + " Release",
-			config:  configCases[3],
-			want:    []string{"-"},
-			wantErr: false,
-		},
-		{
-			name:    schemeCases[4] + " Debug",
-			config:  configCases[4],
-			want:    []string{"iPhone Developer", "Apple Development"},
-			wantErr: false,
-		},
-		{
-			name:    schemeCases[5] + " Release",
-			config:  configCases[5],
-			want:    []string{"iPhone Developer", "Apple Development"},
-			wantErr: false,
-		},
-	}
-	for i, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := projHelpCases[i]
-			got, err := p.ProjectCodeSignIdentity(tt.config)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ProjectHelper.ProjectCodeSignIdentity() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !sliceutil.IsStringInSlice(got, tt.want) {
-				t.Errorf("ProjectHelper.ProjectCodeSignIdentity() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/autoprovision/projecthelper_test.go
+++ b/autoprovision/projecthelper_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 	var err error
 	schemeCases, _, xcProjCases, projHelpCases, configCases, err = initTestCases()
 	if err != nil {
-		t.Fatalf("Failed to initialize test cases, error: %s", err)
+		t.Fatalf("Failed to initialize test cases: %s", err)
 	}
 
 	tests := []struct {
@@ -107,7 +107,7 @@ func TestProjectHelper_ProjectTeamID(t *testing.T) {
 	var err error
 	schemeCases, _, _, projHelpCases, configCases, err = initTestCases()
 	if err != nil {
-		t.Fatalf("Failed to initialize test cases, error: %s", err)
+		t.Fatalf("Failed to initialize test cases: %s", err)
 	}
 
 	tests := []struct {
@@ -344,7 +344,7 @@ func TestProjectHelper_TargetBundleID(t *testing.T) {
 	var err error
 	schemeCases, targetCases, xcProjCases, projHelpCases, configCases, err = initTestCases()
 	if err != nil {
-		t.Fatalf("Failed to initialize test cases, error: %s", err)
+		t.Fatalf("Failed to initialize test cases: %s", err)
 	}
 
 	for i, schemeCase := range schemeCases {
@@ -354,7 +354,7 @@ func TestProjectHelper_TargetBundleID(t *testing.T) {
 			configCases[i],
 		)
 		if err != nil {
-			t.Fatalf("Failed to generate XcodeProj for test case, error: %s", err)
+			t.Fatalf("Failed to generate XcodeProj for test case: %s", err)
 		}
 		xcProjCases = append(xcProjCases, xcProj)
 
@@ -364,7 +364,7 @@ func TestProjectHelper_TargetBundleID(t *testing.T) {
 			configCases[i],
 		)
 		if err != nil {
-			t.Fatalf("Failed to generate projectHelper for test case, error: %s", err)
+			t.Fatalf("Failed to generate projectHelper for test case: %s", err)
 		}
 		projHelpCases = append(projHelpCases, *projHelp)
 	}
@@ -495,7 +495,7 @@ func initTestCases() ([]string, []string, []xcodeproj.XcodeProj, []ProjectHelper
 			configCases[i],
 		)
 		if err != nil {
-			return nil, nil, nil, nil, nil, fmt.Errorf("Failed to generate XcodeProj for test case, error: %s", err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("Failed to generate XcodeProj for test case: %s", err)
 		}
 		xcProjCases = append(xcProjCases, xcProj)
 
@@ -505,7 +505,7 @@ func initTestCases() ([]string, []string, []xcodeproj.XcodeProj, []ProjectHelper
 			configCases[i],
 		)
 		if err != nil {
-			return nil, nil, nil, nil, nil, fmt.Errorf("Failed to generate projectHelper for test case, error: %s", err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("Failed to generate projectHelper for test case: %s", err)
 		}
 		projHelpCases = append(projHelpCases, *projHelp)
 	}
@@ -517,7 +517,7 @@ func TestProjectHelper_targetEntitlements(t *testing.T) {
 	var err error
 	schemeCases, targetCases, xcProjCases, projHelpCases, configCases, err = initTestCases()
 	if err != nil {
-		t.Fatalf("Failed to initialize test cases, error: %s", err)
+		t.Fatalf("Failed to initialize test cases: %s", err)
 	}
 
 	tests := []struct {

--- a/keychain/keychain_test.go
+++ b/keychain/keychain_test.go
@@ -35,7 +35,7 @@ func TestImportCertificate(t *testing.T) {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		t.Errorf("setup: faliled to get working dir, error: %s", err)
+		t.Errorf("setup: faliled to get working dir: %s", err)
 	}
 	dirTest := filepath.Join(cwd, "..", "test")
 	pathGolden := filepath.Join(dirTest, "testkeychain")

--- a/main.go
+++ b/main.go
@@ -153,6 +153,10 @@ func main() {
 	if err != nil {
 		failf(err.Error())
 	}
+
+	// Turn off client debug logs includeing HTTP call debug logs
+	client.EnableDebugLogs = false
+
 	log.Donef("client created for: %s", client.BaseURL)
 
 	// Analyzing project

--- a/main.go
+++ b/main.go
@@ -410,6 +410,10 @@ func main() {
 				// Create BundleID
 				log.Warnf("  App ID not found, generating...")
 				bundleID, err = autoprovision.CreateBundleID(client, bundleIDIdentifier, autoprovision.Entitlement(entitlements))
+				if err != nil {
+					failf(err.Error())
+				}
+
 				if err := autoprovision.SyncBundleID(client, bundleID.ID, autoprovision.Entitlement(entitlements)); err != nil {
 					failf(err.Error())
 				}

--- a/main.go
+++ b/main.go
@@ -321,8 +321,15 @@ func main() {
 		log.Infof("Checking %s provisioning profiles for %d bundle id(s)", distrType, len(entitlementsByBundleID))
 		certType := autoprovision.CertificateTypeByDistribution[distrType]
 		certs := certsByType[certType]
+
 		if len(certs) == 0 {
 			failf("No valid certificate provided for distribution type: %s", distrType)
+		} else if len(certs) > 1 {
+			log.Warnf("Multiple certificates provided for distribution type: %s", distrType)
+			for _, c := range certs {
+				log.Warnf("- %s", c.Certificate.CommonName)
+			}
+			log.Warnf("Using: %s", certs[0].Certificate.CommonName)
 		}
 
 		codesignSettings := CodesignSettings{

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func downloadPKCS12(httpClient *http.Client, certificateURL, passphrase string) 
 func downloadFile(httpClient *http.Client, src string) ([]byte, error) {
 	url, err := url.Parse(src)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse url (%s), error: %s", src, err)
+		return nil, fmt.Errorf("failed to parse url (%s): %s", src, err)
 	}
 
 	// Local file
@@ -79,7 +79,7 @@ func downloadFile(httpClient *http.Client, src string) ([]byte, error) {
 	// Remote file
 	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request, error: %s", err)
+		return nil, fmt.Errorf("failed to create request: %s", err)
 	}
 
 	var contents []byte
@@ -92,11 +92,11 @@ func downloadFile(httpClient *http.Client, src string) ([]byte, error) {
 
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			return fmt.Errorf("failed to download (%s), error: %s", src, err)
+			return fmt.Errorf("failed to download (%s): %s", src, err)
 		}
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				log.Warnf("failed to close (%s) body, error: %s", src, err)
+				log.Warnf("failed to close (%s) body: %s", src, err)
 			}
 		}()
 
@@ -106,7 +106,7 @@ func downloadFile(httpClient *http.Client, src string) ([]byte, error) {
 
 		contents, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("failed to read response (%s), error: %s", src, err)
+			return fmt.Errorf("failed to read response (%s): %s", src, err)
 		}
 
 		return nil
@@ -425,11 +425,11 @@ func main() {
 		}
 
 		if err := projHelper.XcProj.ForceCodeSign(config, target.Name, teamID, codesignSettings.Certificate.CommonName, profile.Attributes.UUID); err != nil {
-			failf("Failed to apply code sign settings for target (%s), error: %s", target.Name, err)
+			failf("Failed to apply code sign settings for target (%s): %s", target.Name, err)
 		}
 
 		if err := projHelper.XcProj.Save(); err != nil {
-			failf("Failed to save xcodeproj (%s), error: %s", projHelper.XcProj.Path, err)
+			failf("Failed to save xcodeproj (%s): %s", projHelper.XcProj.Path, err)
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -258,12 +258,20 @@ func main() {
 		fmt.Println()
 		log.Infof("Checking if %d Bitrise test device(s) are registered on Developer Portal", len(stepConf.DeviceIDs()))
 
+		for _, d := range stepConf.DeviceIDs() {
+			log.Debugf("- %s", d)
+		}
+
 		var err error
 		devices, err = autoprovision.ListDevices(client, "", appstoreconnect.IOSDevice)
 		if err != nil {
 			failf("Failed to list devices: %s", err)
 		}
+
 		log.Printf("%d devices are registered on Developer Portal", len(devices))
+		for _, d := range devices {
+			log.Debugf("- %s (%s)", d.Attributes.Name, d.Attributes.UDID)
+		}
 
 		for _, id := range stepConf.DeviceIDs() {
 			log.Printf("checking if the device (%s) is registered", id)
@@ -338,9 +346,11 @@ func main() {
 		if needToRegisterDevices([]autoprovision.DistributionType{distrType}) {
 			for _, d := range devices {
 				if strings.HasPrefix(string(profileType), "TVOS") && d.Attributes.DeviceClass != "APPLE_TV" {
+					log.Debugf("dropping device %s, since device type: %s, required device type: APPLE_TV", d.ID, d.Attributes.DeviceClass)
 					continue
 				} else if strings.HasPrefix(string(profileType), "IOS") &&
 					string(d.Attributes.DeviceClass) != "IPHONE" && string(d.Attributes.DeviceClass) != "IPAD" && string(d.Attributes.DeviceClass) != "IPOD" {
+					log.Debugf("dropping device %s, since device type: %s, required device type: IPHONE, IPAD or IPOD", d.ID, d.Attributes.DeviceClass)
 					continue
 				}
 				deviceIDs = append(deviceIDs, d.ID)

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,7 @@ func TestDownloadLocalCertificates(t *testing.T) {
 
 	cert, privateKey, err := certificateutil.GenerateTestCertificate(serial, teamID, teamName, commonName, expiry)
 	if err != nil {
-		t.Errorf("init: failed to generate certificate, error: %s", err)
+		t.Errorf("init: failed to generate certificate: %s", err)
 	}
 
 	certInfo := certificateutil.NewCertificateInfo(*cert, privateKey)
@@ -27,20 +27,20 @@ func TestDownloadLocalCertificates(t *testing.T) {
 	passphrase := ""
 	certData, err := certInfo.EncodeToP12(passphrase)
 	if err != nil {
-		t.Errorf("init: failed to encode certificate, error: %s", err)
+		t.Errorf("init: failed to encode certificate: %s", err)
 	}
 
 	p12File, err := ioutil.TempFile("", "*.p12")
 	if err != nil {
-		t.Errorf("init: failed to create temp test file, error: %s", err)
+		t.Errorf("init: failed to create temp test file: %s", err)
 	}
 
 	if _, err = p12File.Write(certData); err != nil {
-		t.Errorf("init: failed to write test file, error: %s", err)
+		t.Errorf("init: failed to write test file: %s", err)
 	}
 
 	if err = p12File.Close(); err != nil {
-		t.Errorf("init: failed to close file, error: %s", err)
+		t.Errorf("init: failed to close file: %s", err)
 	}
 
 	p12path := "file://" + p12File.Name()


### PR DESCRIPTION
- `appstoreconnect.Client.EnableDebugLogs = false` introduced to turn on / off full http call debug logs (only for development, can not be controlled via step input)
- `reason, error: deeper reason` -> `reason: deeper reason`
- cert lis printing updated from 

```
[
cert 1
cert 2
]
```

to

```
- cert 1
- cert 2
```

- some logs moved from functions to the main function
- info, warning, fail logs with Capital letter
- unused ProjectCodeSignIdentity removed
- general log revision and improvements
