### PR TITLE
handle invalid profiles

### DIFF
--- a/autoprovision/profilehelper.go
+++ b/autoprovision/profilehelper.go
@@ -55,9 +55,8 @@ func FindProfile(client *appstoreconnect.Client, profileType appstoreconnect.Pro
 		PagingOptions: appstoreconnect.PagingOptions{
 			Limit: 1,
 		},
-		FilterProfileState: appstoreconnect.Active,
-		FilterProfileType:  profileType,
-		FilterName:         name,
+		FilterProfileType: profileType,
+		FilterName:        name,
 	}
 
 	r, err := client.Provisioning.ListProfiles(opt)


### PR DESCRIPTION
The provisioning profile name needs to be unique.
The profile can turn into an invalid state (for example if you modify the included bundle id).

The changes:
- fetch all profiles (including invalid ones)
- in case of invalid profile, delete it and regenerate