### PR TITLE
add platform to the Bitrise managed profile name

### DIFF
--- a/lib/autoprovision/portal/profile_client.rb
+++ b/lib/autoprovision/portal/profile_client.rb
@@ -95,7 +95,7 @@ module Portal
       all_profiles = ProfileClient.fetch_profiles(false, platform)
 
       # search for the Bitrise managed profile
-      profile_name = "Bitrise #{distribution_type} - (#{app.bundle_id})"
+      profile_name = "Bitrise #{platform} #{distribution_type} - (#{app.bundle_id})"
       profile = all_profiles.select { |prof| prof.name == profile_name }.first
 
       unless profile.nil?


### PR DESCRIPTION
Modifies the Profile name layout from: `Bitrise <distribution type> - (<bundle id>)` to `Bitrise <platform> <distribution type> - (<bundle id>)`