### PR TITLE
Fix Bundler 2 issue

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -6,11 +6,7 @@ THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 gem install bundler -v 1.17.3
 
-bundle -v
-
 export BUNDLE_GEMFILE="$THIS_SCRIPT_DIR/Gemfile"
-
-bundle -v
 
 set +e
 echo '$' "bundle install"

--- a/step.sh
+++ b/step.sh
@@ -3,7 +3,14 @@
 set -e
 THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+
+gem install bundler -v 1.17.3
+
+bundle -v
+
 export BUNDLE_GEMFILE="$THIS_SCRIPT_DIR/Gemfile"
+
+bundle -v
 
 set +e
 echo '$' "bundle install"


### PR DESCRIPTION
Bundler 2 [auto switches](https://bundler.io/guides/bundler_2_upgrade.html#version-autoswitch) to Bundler 1 if Gemfile.lock selects Bundler 1. To do so Bundler 1 version needs to be installed.

Test `test_xcode_11_ccertificate` is running on Edge stack, as the issue came in that environment, see the CI builds.