### PR TITLE
TOOL-1454 Force codesign settings for required distribution type. This allows t…

### DIFF
--- a/main.go
+++ b/main.go
@@ -471,9 +471,9 @@ func main() {
 		fmt.Println()
 		log.Infof("  Target: %s", target.Name)
 
-		codesignSettings, ok := codesignSettingsByDistributionType[autoprovision.Development]
+		codesignSettings, ok := codesignSettingsByDistributionType[stepConf.DistributionType()]
 		if !ok {
-			failf("No development codesign settings ensured")
+			failf("No codesign settings ensured for distribution type %s", stepConf.DistributionType())
 		}
 		teamID = codesignSettings.Certificate.TeamID
 

--- a/main.go
+++ b/main.go
@@ -471,7 +471,12 @@ func main() {
 		fmt.Println()
 		log.Infof("  Target: %s", target.Name)
 
-		codesignSettings, ok := codesignSettingsByDistributionType[stepConf.DistributionType()]
+		forceCodesignDistribution := stepConf.DistributionType()
+		if _, isDevelopmentAvailable := codesignSettingsByDistributionType[autoprovision.Development]; isDevelopmentAvailable {
+			forceCodesignDistribution = autoprovision.Development
+		}
+
+		codesignSettings, ok := codesignSettingsByDistributionType[forceCodesignDistribution]
 		if !ok {
 			failf("No codesign settings ensured for distribution type %s", stepConf.DistributionType())
 		}


### PR DESCRIPTION
…o useDistribution certificates for e.g. ad-hoc export, when there is no Development Certificate uploaded.