### PR TITLE
Make log output less confusing

### DIFF
--- a/lib/autoprovision/project_helper.rb
+++ b/lib/autoprovision/project_helper.rb
@@ -43,7 +43,7 @@ class ProjectHelper
         raise "build configuration (#{configuration_name}) not defined for target: #{@main_target.name}" unless configuration
       end
 
-      Log.warn("Using defined build configuration: #{configuration_name} instead of the scheme's default one: #{default_configuration_name}")
+      Log.warn("Using defined build configuration: #{configuration_name} instead of the scheme's default one (#{default_configuration_name})")
       @configuration_name = configuration_name
     end
 


### PR DESCRIPTION
Few times I was confused with this output:

```
Analyzing project
Using defined build configuration: Dev instead of the scheme's default one: Release
```

I hope this change makes it more precise:

```
Analyzing project
Using defined build configuration: Dev instead of the scheme's default one (Release)
```

Thanks.