### PR TITLE
Fix compatibility with Xcode 11.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
-    xcodeproj (1.12.0)
+    xcodeproj (1.16.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)


### PR DESCRIPTION
`xcodeproj` needs to be at least 1.16.0 to be able to run on Xcode 11.4 projects.

Fixes #122