### PR TITLE
Update xcodeproj version to support Xcode 12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.1)
+    CFPropertyList (3.0.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
@@ -107,7 +107,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nanaimo (0.2.6)
+    nanaimo (0.3.0)
     naturally (2.2.0)
     openssl (2.1.2)
       ipaddr
@@ -171,12 +171,12 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
-    xcodeproj (1.16.0)
+    xcodeproj (1.18.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.6)
+      nanaimo (~> 0.3.0)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.0)
@@ -191,7 +191,7 @@ DEPENDENCIES
   plist
   rspec
   rubocop (= 0.58.2)
-  xcodeproj
+  xcodeproj (= 1.18.0)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Due to our requirements we can't migrate over to the newer bitrise step using the App Store Connect API, but we do need support for Xcode 12.

This bumps the xcodeproj version to the latest version 1.18.0 which supports the new `objectVersion` added in Xcode 12.

Fixes the issue raised in https://github.com/bitrise-steplib/steps-ios-auto-provision/issues/132