### PR TITLE
Remove unused workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,12 +1,7 @@
-format_version: 11
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
-  ci:
-    after_run:
-    - check
-    - e2e
-
   check:
     steps:
     - script:


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Remove old validation workflows that were used in the old CI setup. These are not used anymore and only `check` and `e2e` are needed.

Part of https://bitrise.atlassian.net/browse/STEP-1144
